### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ A 12306 ticket search server based on the Model Context Protocol (MCP). The serv
 
 基于 Model Context Protocol (MCP) 的12306购票搜索服务器。提供了简单的API接口，允许大模型利用接口搜索12306购票信息。
 
+<a href="https://glama.ai/mcp/servers/@freestylefly/12306-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@freestylefly/12306-mcp/badge" alt="12306-MCP MCP server" />
+</a>
+
 ## <div align="center">🔥应用</div>
 
 1、在 Cursor 中使用


### PR DESCRIPTION
This PR adds a badge for the [12306-MCP](https://glama.ai/mcp/servers/@freestylefly/12306-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@freestylefly/12306-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@freestylefly/12306-mcp/badge" alt="12306-MCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.